### PR TITLE
Add health check endpoint

### DIFF
--- a/clojure-backend-api/src/clojure_backend_api/core.clj
+++ b/clojure-backend-api/src/clojure_backend_api/core.clj
@@ -133,6 +133,10 @@
 ;;; ----------------------------------------------------------------
 
 (defroutes app-routes
+  (GET "/health" []
+    {:status 200
+     :headers {"Content-Type" "text/plain"}
+     :body "OK"})
   (context "/api" []
     (GET "/horarios" [] (get-all-horarios-handler))
     (POST "/horarios/editar" request (update-horarios-handler request))


### PR DESCRIPTION
A new GET /health endpoint was added to the API.
This endpoint returns a 200 OK status and the text "OK" in the body. It can be used by external monitoring services to verify if the API is online and functional.